### PR TITLE
cambalache: fix broadwayd

### DIFF
--- a/pkgs/development/tools/cambalache/default.nix
+++ b/pkgs/development/tools/cambalache/default.nix
@@ -1,33 +1,29 @@
-{ stdenv
-, lib
-, fetchFromGitLab
+{ stdenv, lib, fetchFromGitLab
 , python3
-, meson
-, ninja
-, pkg-config
+, meson, ninja, pkg-config
 , gobject-introspection
-, desktop-file-utils
-, shared-mime-info
+, desktop-file-utils, shared-mime-info
 , wrapGAppsHook
-, glib
-, gtk3
-, gtk4
+, appstream-glib , gtk3, gtk4
 , webkitgtk
-, unstableGitUpdater
+, genericUpdater
+, useGTK3Broadwayd ? false
+, useGTK4Broadwayd ? false
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "cambalache";
-  version = "unstable-2021-09-23";
+  version = "0.8.0";
 
   format = "other";
+  strictDeps = false; # https://github.com/NixOS/nixpkgs/issues/56943
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "jpu";
     repo = pname;
-    rev = "69b39dedbf9ccb3fac6afaa8f533d79e68d36792";
-    sha256 = "X+VOZQicUUrHsXm+ttLAPrtc94pvTdjDI8hIe/Zd3ks=";
+    rev = version;
+    sha256 = "05hf45v24l73fwv36bf90h6ksf6axvi8f4mddyq24x63w1yndhg9";
   };
 
   nativeBuildInputs = [
@@ -40,20 +36,17 @@ python3.pkgs.buildPythonApplication rec {
     wrapGAppsHook
   ];
 
-  pythonPath = with python3.pkgs; [
+  propagatedBuildInputs = with python3.pkgs; [
     pygobject3
     lxml
   ];
 
   buildInputs = [
-    glib
+    appstream-glib
     gtk3
     gtk4
     webkitgtk
   ];
-
-  # Not compatible with gobject-introspection setup hooks.
-  strictDeps = false;
 
   # Prevent double wrapping.
   dontWrapGApps = true;
@@ -65,29 +58,34 @@ python3.pkgs.buildPythonApplication rec {
   preFixup = ''
     # Let python wrapper use GNOME flags.
     makeWrapperArgs+=(
+      # For gtk3 broadwayd
+      ${ lib.optionalString useGTK3Broadwayd ''--prefix PATH : "${gtk3}/bin"''}
       # For gtk4-broadwayd
-      --prefix PATH : "${gtk4.dev}/bin"
+      ${ lib.optionalString useGTK4Broadwayd ''--prefix PATH : "${gtk4.dev}/bin"''}
       "''${gappsWrapperArgs[@]}"
     )
   '';
 
   postFixup = ''
+    mkdir -p $out/bin
+    ${ lib.optionalString (!useGTK3Broadwayd) "install ${gtk3}/bin/broadwayd $out/bin/"}
+    ${ lib.optionalString (!useGTK4Broadwayd) "install ${gtk4.dev}/bin/gtk4-broadwayd $out/bin/"}
     # Wrap a helper script in an unusual location.
     wrapPythonProgramsIn "$out/${python3.sitePackages}/cambalache/priv/merengue" "$out $pythonPath"
   '';
 
   passthru = {
-    updateScript = unstableGitUpdater {
+    updateScript = genericUpdater {
       url = "${meta.homepage}.git";
     };
   };
 
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/jpu/cambalache";
-    description = "RAD tool for GTK 4 and 3";
+    description = "RAD tool for Gtk 4 and 3 with a clear MVC design and data model first philosophy.";
     maintainers = teams.gnome.members;
     license = with licenses; [
-      lgpl2Only # Cambalache
+      lgpl21Only # Cambalache
       gpl2Only # tools
     ];
     platforms = platforms.unix;


### PR DESCRIPTION
Fix gtk3/4-broadwayd
Switch to release 0.8.0
Fix license

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/#sec-conf-file))
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [21.11 Release Notes (or backporting 21.05 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2111-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
